### PR TITLE
docs: Refactor headings and links in IETF standards guide

### DIFF
--- a/Guide to the IETF standards process.md
+++ b/Guide to the IETF standards process.md
@@ -14,45 +14,41 @@ The IETF follows open and well-documented processes for its work, including sett
 BODY 
 -->
 
-* <a href="#overview">Overview</a><br>
-* <a href="#groups">Groups involved in the Standards process</a><br>
-        * <a href="#wgs">Working Groups</a><br>
-        * <a href="#directorates">Directorates and teams</a><br>
-        * <a href="#iesg">Internet Engineering Steering Group</a><br>
-* <a href="#flow">General process flow</a><br>
-		* <a href="#individual-phase"> Individual phase</a><br>
-		* <a href="#wg-phase">Working Group phase</a><br>
-		* <a href="#iesg-phase">IESG phase</a><br>
-* <a href="#diagram">Diagram of generalized IETF standards process
-* <a href="#more">More information</a><br>
+* <a href="#overview">Overview</a>
+* <a href="#groups">Groups involved in the Standards process</a>
+   * <a href="#wgs">Working Groups</a>
+   * <a href="#directorates">Directorates and teams</a>
+   * <a href="#iesg">Internet Engineering Steering Group</a>
+* <a href="#flow">General process flow</a>
+   * <a href="#individual-phase"> Individual phase</a>
+   * <a href="#wg-phase">Working Group phase</a>
+   * <a href="#iesg-phase">IESG phase</a>
+* <a href="#diagram">Diagram of generalized IETF standards process</a>
+* <a href="#more">More information</a>
 
 The IETF standards process, related processes, and the groups that guide and oversee them are defined in [RFCs](https://www.ietf.org/process/rfcs/)—many of which are further codified as Best Current Practices ([BCPs](https://www.ietf.org/process/rfcs/#series-structure))—and statements by the Internet Engineering Steering Group ([IESG](https://www.ietf.org/about/groups/iesg/)). A complementary [Guide to IETF process documents](https://www.ietf.org/process/informal/) provides a more in-depth review of the variety of documents that describe the IETF standards process, as well as related groups and processes.
 
 This guide focuses on the process once ideas are determined to be within the scope of the IETF. The IETF also works on specifications that are within its scope but not Internet standards; his page includes some information about those to provide additional clarity about and context for its work on standards. 
 
-# <a id="overview">Overview
-
+## <a id="overview">Overview</a>
 The IETF standards process starts when an individual (or individuals) shares an idea, usually in the form of an Internet-Draft ([I-D](https://www.ietf.org/participate/ids/)) document, for further discussion within the IETF community. IETF participation is voluntary and there is no top-down plan that requires any particular topic to be worked on or idea to be adopted. For a more complete description of how new work may be undertaken in the IETF, see the [Bringing new work to the IETF webpage](https://www.ietf.org/process/new-work/).
 
 [RFCs](https://www.ietf.org/process/rfcs/) are the core output of the IETF process. An IETF RFC is produced when, as determined by the Internet Engineering Steering Group ([IESG](https://www.ietf.org/about/groups/iesg/)), there is consensus that an I-D ought to be published in the IETF stream of the RFC document series. Not all RFCs are produced by the IETF and not the RFCs produced by IETF processes describe Internet Standards.
 
-# <a id="groups">Groups involved in the Standards process
-
+## <a id="groups">Groups involved in the Standards process</a>
 Below is a summary of groups involved in the IETF standards process. [RFC 9281](https://www.rfc-editor.org/rfc/rfc9281.html) provides a more complete description of these and other groups.
 
-## <a id="wgs">Working Groups
-
+### <a id="wgs">Working Groups</a>
 The vast majority of the IETF's work is done in its many Working Groups, of which there are well over one hundred active at any time. A [dedicated guide to IETF Working Groups](https://www.ietf.org/process/wgs/) explains the basics of how they work, how to participate in one, and what to expect.
 
-## <a id="directorates">Directorates and teams
-
+### <a id="directorates">Directorates and teams</a>
 [IETF Directorates](https://datatracker.ietf.org/dir/) (e.g. Transport Area Review Team, Security Area Directorate, General Area Review Team) provide review and advice to support Area Directors. These comprise experienced members of the IETF and the technical community represented by the Area. The specific name and the details of the role for each group differ from area to area, but the primary intent is that these groups assist the Area Director(s), e.g., with the review of specifications produced in the Area. However, they may also review other documents. For example the Security Area Directorate provides review of nearly all documents proposed to be published as RFCs.
 
-## <a id="iesg">Internet Engineering Steering Group (IESG)
+### <a id="iesg">Internet Engineering Steering Group (IESG)</a>
 
 The [IESG](https://www.ietf.org/about/groups/iesg/) reviews and approves working group documents and candidates for the IETF standards track.The IESG ensures that the documents are of a sufficient quality to be published as RFCs: that they describe their subject matter well, and that there are no outstanding engineering issues that should be addressed before publication. The degree of review will vary with the intended status and perceived importance of the documents.
 
-# <a id="flow">General process flow
+## <a id="flow">General process flow</a>
 
 The basic formal definition of the IETF standards process is [RFC 2026](https://www.rfc-editor.org/info/rfc2026/). It embodies and aims to achieve the IETF’s [mission](https://www.ietf.org/about/introduction/#mission) while adhering to its [principles](https://www.ietf.org/about/introduction/#principles), which include open processes, technical competence, and rough consensus and running code as described in RFC ([BCP 95](https://www.rfc-editor.org/info/bcp95), Since publication of RFC 2026, several more RFCs have been published adding to and amending the process; these are collected in [BCP 9](https://www.rfc-editor.org/info/bcp9/) (BCP stands for "Best Current Practice"). 
 
@@ -60,7 +56,7 @@ The intellectual property rules are now separate, in RFC 5378 ([BCP 78](https://
 
 While there are many paths an idea may take in the IETF, a general flow for many is this:
 
-## <a id="individual-phase">Individual Phase
+### <a id="individual-phase">Individual Phase</a>
 
 1. **Internet-Draft (I-D) Authoring**
    
@@ -68,7 +64,7 @@ While there are many paths an idea may take in the IETF, a general flow for many
 
    I-Ds may be considered in a variety of forums in the IETF. For details, see the ["Bringing new work to the IETF" webpage](https://www.ietf.org/process/new-work/#appropriate-part). Not all I-Ds gain enough traction to progress further within the IETF.
 
-## <a id="wg-phase">Working Group Phase
+### <a id="wg-phase">Working Group Phase</a>
 
 Most I-Ds that do progress within the IETF do so within a Working Group. Once an I-D has been introduced to and discussed within a working group, it generally follows these steps:
 
@@ -83,7 +79,7 @@ Most I-Ds that do progress within the IETF do so within a Working Group. Once an
 6. **Working Group Last Call (WGLC)**  
    WG Chairs formally initiate this step by sending an email to the WG mailing list with a date by which all comments should be received. The goal of WGLC is to understand whether or not a document has rough consensus among WG participants (as judged by the WG Chairs) to progress to the next step of publication as an RFC. After review, the chairs may decide that a document does not have consensus in its current form, in which case it usually will be subject to further discussion in the WG, and another WGLC will be held. If the WG chairs decide an I-D does have consensus, then it will be submitted to the AD responsible for publication as an RFC.
 
-## <a id="iesg-phase">IESG Phase
+### <a id="iesg-phase">IESG Phase</a>
 
 7. **Area Director (AD) Evaluation**  
    In this step, the responsible AD reviews the document with an aim of making sure it is ready for an IETF-wide Last Call (LC). The authors should reply to any comments or questions, but replies from others in the WG are also welcome. If major issues are found, a document's progress will be blocked until they are dealt with, which may require a new version of the I-D.
@@ -103,7 +99,7 @@ Most I-Ds that do progress within the IETF do so within a Working Group. Once an
 13. **Publication as an RFC**  
    Once IESG approves an I-D for publication, the document is handed over to the RFC Editor for publication. At this stage, the RFC Publication Center (RPC) does a thorough editorial review to be sure the I-D is clear and comports with RFC Series editorial guidelines and style. Authors may be asked for clarification on specific points and will, during the phase called “AUTH48” be asked about specific changes the RPC wants to make. Once AUTH48 is complete, the I-D is officially published as an RFC by the RFC Editor.
 
-# <a id="diagram">Diagram of generalized IETF standards process
+## <a id="diagram">Diagram of generalized IETF standards process</a>
 
 ```mermaid
 graph TD
@@ -143,7 +139,7 @@ graph TD
     style IESG_Eval fill:#3e95c8,stroke:#0b8cc5
 ```
 
-# <a id="more">More information
+## <a id="more">More information</a>
 
 [Internet-Drafts](https://www.ietf.org/participate/ids/)
 


### PR DESCRIPTION
Updated headings and links for clarity and consistency in the IETF standards process guide.